### PR TITLE
Adding better docs for connecting to database from Vapor 3

### DIFF
--- a/docs/database/basics.md
+++ b/docs/database/basics.md
@@ -38,14 +38,58 @@ Tokens are the one you connect to the database from your Vapor app. These are na
 
 `DB_<ENGINE>` e.g. `DB_POSTGRESQL` if you have two databases of the same engine they will be named `DB_POSTGRESQL` and `DB_POSTGRESQL2`
 
-To connect to it from your Vapor 3 app, simply use:
+## Connect in Vapor 3
+
+### PostgreSQL
+
+The following config will locally connect to localhost, and on Vapor Cloud use `DB_POSTGRESQL` variable.
 
 ```swift
-let databaseConfig: PostgreSQLDatabaseConfig
-let url = Environment.get("DB_POSTGRESQL")
-
-guard let urlConfig = PostgreSQLDatabaseConfig(url: url) else {
-    fatalError("Failed to create PostgreSQLConfig")
+services.register { c -> PostgreSQLDatabaseConfig
+    switch c.environment {
+    case .development:
+        return .init(
+            hostname: "localhost",
+            port: 5432,
+            username: "vapor",
+            password: "vapor",
+            database: "database"
+        )
+    default:
+        guard let url = Environment.get("DB_POSTGRESQL") else {
+            throw Abort(.internalServerError, reason: "No DB_POSTGRESQL env var set")
+        }
+        guard let config = try PostgreSQLDatabaseConfig(url: url) else {
+            throw Abort(.internalServerError, reason: "Could not create PostgreSQL config from DB_POSTGRESQL env var")
+        }
+        return config
+    }
 }
-databaseConfig = urlConfig
+```
+
+### MySQL
+
+The following config will locally connect to localhost, and on Vapor Cloud use `DB_MYSQL` variable.
+
+```swift
+services.register { c -> MySQLDatabaseConfig
+    switch c.environment {
+    case .development:
+        return .init(
+            hostname: "localhost",
+            port: 3306,
+            username: "vapor",
+            password: "vapor",
+            database: "database"
+        )
+    default:
+        guard let url = Environment.get("DB_MYSQL") else {
+            throw Abort(.internalServerError, reason: "No DB_MYSQL env var set")
+        }
+        guard let config = try MySQLDatabaseConfig(url: url) else {
+            throw Abort(.internalServerError, reason: "Could not create MySQL config from DB_MYSQL env var")
+        }
+        return config
+    }
+}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Welcome to Vapor Cloud 2's documentation. Use the menu on the left or the search
 
 ## Quick Start
 
-If you are new to Vapor Cloud, visit [Quick Start](/quick-start.md) for a tutorial on deploying your first application.
+If you are new to Vapor Cloud, visit [Quick Start](quick-start.md) for a tutorial on deploying your first application.
 
 ## Contribute
 

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -1,0 +1,10 @@
+# Redis
+
+Redis allows for creating Redis servers, which is a good way to do e.g. Cache in your app.
+
+This means if you need to fetch large amounts of the same data from your app, you can cache the data in Redis.
+
+When creating a Redis product, you get your own server, only used for that specific environment, meaning no shared data with other clients. Even on the free plan.
+
+!!! note
+    More info when the product is available

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -15,5 +15,7 @@ It's possible to connect to Redis servers externally, either through CLI or GUI 
 
 Each redis server have a password, that can be easily rotated for security.
 
+When connecting to a Redis server, it will get a specific port, it's important to specify this when connecting to the server.
+
 !!! note
     Later it will also be possible to setup IP Whitelist, to only allow certain ips to access the redis server.

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -1,10 +1,19 @@
 # Redis
 
+!!! note
+    More info when the product is available
+
 Redis allows for creating Redis servers, which is a good way to do e.g. Cache in your app.
 
 This means if you need to fetch large amounts of the same data from your app, you can cache the data in Redis.
 
 When creating a Redis product, you get your own server, only used for that specific environment, meaning no shared data with other clients. Even on the free plan.
 
+## External access
+
+It's possible to connect to Redis servers externally, either through CLI or GUI interface for easy debugging Redis.
+
+Each redis server have a password, that can be easily rotated for security.
+
 !!! note
-    More info when the product is available
+    Later it will also be possible to setup IP Whitelist, to only allow certain ips to access the redis server.

--- a/docs/redis/storage.md
+++ b/docs/redis/storage.md
@@ -1,0 +1,7 @@
+# Redis Storage
+
+All Redis servers per default uses ephemeral storage, meaning if the server reboots or are shutdown, the entire Redis server will be cleared for all data.
+
+This is usually fine for using Redis for cache, since the data don't need to be consistent.
+
+However this can't be used as an actual database with permanent data. For this we will later be adding a Block storage system to Redis, so redis servers can have persistent storage and backups.

--- a/docs/redis/storage.md
+++ b/docs/redis/storage.md
@@ -2,8 +2,8 @@
 
 All Redis servers per default uses ephemeral storage, meaning if the server reboots or are shutdown, the entire Redis server will be cleared for all data.
 
-This is usually fine for using Redis for cache, since the data don't need to be consistent.
+This is usually fine for using Redis for cache, since the data doesn't need to be consistent.
 
-However this can't be used as an actual database with permanent data. For this we will later be adding a Block storage system to Redis, so redis servers can have persistent storage and backups.
+However this can't be used as an actual database with permanent data.
 
 This also means if you shutdown the redis server, the ephemeral disc will be purged.

--- a/docs/redis/storage.md
+++ b/docs/redis/storage.md
@@ -5,3 +5,5 @@ All Redis servers per default uses ephemeral storage, meaning if the server rebo
 This is usually fine for using Redis for cache, since the data don't need to be consistent.
 
 However this can't be used as an actual database with permanent data. For this we will later be adding a Block storage system to Redis, so redis servers can have persistent storage and backups.
+
+This also means if you shutdown the redis server, the ephemeral disc will be purged.

--- a/docs/replica/replica.md
+++ b/docs/replica/replica.md
@@ -1,0 +1,31 @@
+# Replica
+
+Replica are our product for hosting applications. Each replica is a full container based on the specs in the Dockerfile specified in the project.
+
+When a replica is deployed or changed, our system will assign each replica to an available worker node. If an environment have multiple replicas, our system will try to assign each replica to different worker nodes, so if one crashes, the app is still available.
+
+Depending on the plan selected we have two different sizes of worker nodes.
+
+| Plans | Worker node | Description |
+| ---- | ----------- | ----------- |
+| Dev Free / Dev Hobby | web-free | Worker node with minimal CPU for developing purpose |
+| Other plans | web | Worker node with larger CPU, allowing for small CPU bursts above the plans limitations |
+
+## CPU Limitations
+
+*CPU is a soft limit*
+
+Each replica plan will have a certain amount of CPU allowed to be used. If a Replica goes above it's CPU limit,
+the admin of the organization will receive an Email.
+
+If the CPU limit keeps being above the limit, the replica will be rebooted.
+
+If it still keeps above the limit the replica will be shutdown.
+
+## Memory Limitations
+
+*Memory is a hard limit*
+
+Each replica plan will have a certain amount of Memory allowed to be used. If a replica reaches it's memory limit, the replica will reboot, this reboot usually takes 4-5 seconds.
+
+All crashes will be shown from the logs.

--- a/docs/replica/storage.md
+++ b/docs/replica/storage.md
@@ -1,0 +1,18 @@
+# Replica Storage
+
+!!! warning
+    All replicas uses ephemeral storage
+
+## Ephemeral storage
+
+Ephemeral storage is a temporary disc storage created for all Replicas in Vapor Cloud.
+This gives a way to store the application on Vapor Cloud.
+
+It's important to know that everytime a replica is shutdown/rebooted the ephemeral storage
+will be deleted, and a new drive is created. This means if you e.g. Store an image during runtime
+and the application reboots (Crashes, redeploy etc.) Everything not in Git will be deleted.
+
+## Block storage
+
+!!! note
+    We are planning on building Block storage, allowing for stable storage, however it's not ready yet.

--- a/docs/replica/storage.md
+++ b/docs/replica/storage.md
@@ -1,7 +1,7 @@
 # Replica Storage
 
 !!! warning
-    All replicas uses ephemeral storage
+    All replicas use ephemeral storage
 
 ## Ephemeral storage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
     - 'Storage': 'replica/storage.md'
 - 'Database': 'database/basics.md'
 - 'Redis':
+    - 'Redis': 'redis/redis.md'
     - 'Storage': 'redis/storage.md'
 markdown_extensions:
     - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,12 @@ pages:
     - 'Templates': 'docker/templates.md'
 - 'Git': 'git/basics.md'
 - 'Config Vars': 'config/basics.md'
+- 'Replica':
+    - 'Replica': 'replica/replica.md'
+    - 'Storage': 'replica/storage.md'
 - 'Database': 'database/basics.md'
+- 'Redis':
+    - 'Storage': 'redis/storage.md'
 markdown_extensions:
     - admonition
     - codehilite:


### PR DESCRIPTION
**Update**
Also added info about Replica/Redis storage, and info on the replica product

Make it more specific how to connect to a Cloud 2 database in Vapor 3 for both psql and mysql